### PR TITLE
added Bootstrapper.destroyHabitats method

### DIFF
--- a/src/Bootstrapper.js
+++ b/src/Bootstrapper.js
@@ -205,7 +205,7 @@ export default class Bootstrapper {
 	 * Destroy habitat instances for the container
 	 * @param {function}	[cb=null]	- Optional callback
 	 */
-	destroyHabitats(cb = null) {
+	unmountHabitats(cb = null) {
 		// Get open habitats for this container
 		const habitats = Habitat.listHabitats(this.__container__.id);
 
@@ -229,7 +229,7 @@ export default class Bootstrapper {
 	 * @param {function}	[cb=null]	- Optional callback
 	 */
 	dispose(cb = null) {
-		this.destroyHabitats(() => {
+		this.unmountHabitats(() => {
 			// Reset and release
 			this.__container__ = null;
 	

--- a/src/Bootstrapper.js
+++ b/src/Bootstrapper.js
@@ -200,13 +200,12 @@ export default class Bootstrapper {
 			},
 		);
 	}
-
+	
 	/**
-	 * Dispose the container and destroy habitat instances
+	 * Destroy habitat instances for the container
 	 * @param {function}	[cb=null]	- Optional callback
 	 */
-	dispose(cb = null) {
-
+	destroyHabitats(cb = null) {
 		// Get open habitats for this container
 		const habitats = Habitat.listHabitats(this.__container__.id);
 
@@ -216,15 +215,31 @@ export default class Bootstrapper {
 			Habitat.destroy(habitats[i]);
 		}
 
-		// Reset and release
-		this.__container__ = null;
-
 		// Lifecycle event
-		if (typeof this.didDispose === 'function') {
-			this.didDispose();
+		if (typeof this.didDestroyHabitats === 'function') {
+			this.didDestroyHabitats();
 		}
 
 		// Handle callback
 		_callback(cb, this);
+	}
+
+	/**
+	 * Dispose the container and destroy habitat instances
+	 * @param {function}	[cb=null]	- Optional callback
+	 */
+	dispose(cb = null) {
+		this.destroyHabitats(() => {
+			// Reset and release
+			this.__container__ = null;
+	
+			// Lifecycle event
+			if (typeof this.didDispose === 'function') {
+				this.didDispose();
+			}
+	
+			// Handle callback
+			_callback(cb, this);
+		});
 	}
 }


### PR DESCRIPTION
I am quite possibly doing something wrong but I found that my components on different pages of my PHP app were not being unmounted when changing pages. Using `this.dispose()` was removing the Bootstrapper as well so I couldnt manually unload the mounted components so I had to hack it like this:
```
class MyApp extends Bootstrapper {
  constructor() {
    super();
  }

  cleanUp() {
    // Get open habitats for this container
    const habitats = Habitat.listHabitats(this.__container__.id);
    // Clean up
    for (let i = 0; i < habitats.length; ++i) {
      this.__container__.factory.dispose(habitats[i]);
      Habitat.destroy(habitats[i]);
    }
  }
}
```
Which seemed to fixed my problem. And I thought this might be useful for others too to be included in the API.