### PR TITLE
Unmount habitats typescript

### DIFF
--- a/packages/react-habitat/index.d.ts
+++ b/packages/react-habitat/index.d.ts
@@ -62,6 +62,11 @@ declare module "react-habitat" {
 		update: (node?: Element) => void;
 
 		/**
+		 * Unmount all React Habitat instances
+		 */
+		unmountHabitats: () => void
+
+		/**
 		 * Dispose of the container
 		*/
 		dispose: () => void;
@@ -156,6 +161,11 @@ declare module "react-habitat" {
 		 * Stop the DOM watcher if running
 		 */
 		stopWatcher: () => void;
+
+		/**
+		 * Unmount all React Habitat instances
+		 */
+		unmountHabitats: () => void
 
 		/**
 		 * Disposes the container

--- a/packages/react-habitat/package-lock.json
+++ b/packages/react-habitat/package-lock.json
@@ -10,7 +10,7 @@
 			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0"
+				"@babel/highlight": "^7.0.0"
 			}
 		},
 		"@babel/highlight": {
@@ -19,9 +19,9 @@
 			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"esutils": "2.0.2",
-				"js-tokens": "4.0.0"
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -30,7 +30,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.3"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -39,9 +39,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -62,7 +62,7 @@
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -73,8 +73,8 @@
 			"integrity": "sha512-fljtxFzJfYbJnhBkxHE3uxPB/Not2TG0F3PAkcVGSnzUIvVhwlUog0hK5MFMrNTOYvFTclYIfJAyRHNKW3kgJA==",
 			"dev": true,
 			"requires": {
-				"eslint": "4.19.1",
-				"eslint-plugin-import": "2.14.0"
+				"eslint": "^4.18.2",
+				"eslint-plugin-import": "^2.9.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -89,7 +89,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.3"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -98,9 +98,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"cross-spawn": {
@@ -109,9 +109,9 @@
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.1",
-						"shebang-command": "1.2.0",
-						"which": "1.2.14"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -120,7 +120,7 @@
 					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
 					"dev": true,
 					"requires": {
-						"ms": "2.1.1"
+						"ms": "^2.1.1"
 					}
 				},
 				"eslint": {
@@ -129,44 +129,44 @@
 					"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 					"dev": true,
 					"requires": {
-						"ajv": "5.5.2",
-						"babel-code-frame": "6.22.0",
-						"chalk": "2.4.1",
-						"concat-stream": "1.6.2",
-						"cross-spawn": "5.1.0",
-						"debug": "3.2.5",
-						"doctrine": "2.1.0",
-						"eslint-scope": "3.7.3",
-						"eslint-visitor-keys": "1.0.0",
-						"espree": "3.5.4",
-						"esquery": "1.0.1",
-						"esutils": "2.0.2",
-						"file-entry-cache": "2.0.0",
-						"functional-red-black-tree": "1.0.1",
-						"glob": "7.1.2",
-						"globals": "11.7.0",
-						"ignore": "3.3.10",
-						"imurmurhash": "0.1.4",
-						"inquirer": "3.3.0",
-						"is-resolvable": "1.1.0",
-						"js-yaml": "3.12.0",
-						"json-stable-stringify-without-jsonify": "1.0.1",
-						"levn": "0.3.0",
-						"lodash": "4.17.4",
-						"minimatch": "3.0.4",
-						"mkdirp": "0.5.1",
-						"natural-compare": "1.4.0",
-						"optionator": "0.8.2",
-						"path-is-inside": "1.0.2",
-						"pluralize": "7.0.0",
-						"progress": "2.0.0",
-						"regexpp": "1.1.0",
-						"require-uncached": "1.0.3",
-						"semver": "5.3.0",
-						"strip-ansi": "4.0.0",
-						"strip-json-comments": "2.0.1",
+						"ajv": "^5.3.0",
+						"babel-code-frame": "^6.22.0",
+						"chalk": "^2.1.0",
+						"concat-stream": "^1.6.0",
+						"cross-spawn": "^5.1.0",
+						"debug": "^3.1.0",
+						"doctrine": "^2.1.0",
+						"eslint-scope": "^3.7.1",
+						"eslint-visitor-keys": "^1.0.0",
+						"espree": "^3.5.4",
+						"esquery": "^1.0.0",
+						"esutils": "^2.0.2",
+						"file-entry-cache": "^2.0.0",
+						"functional-red-black-tree": "^1.0.1",
+						"glob": "^7.1.2",
+						"globals": "^11.0.1",
+						"ignore": "^3.3.3",
+						"imurmurhash": "^0.1.4",
+						"inquirer": "^3.0.6",
+						"is-resolvable": "^1.0.0",
+						"js-yaml": "^3.9.1",
+						"json-stable-stringify-without-jsonify": "^1.0.1",
+						"levn": "^0.3.0",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.2",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"optionator": "^0.8.2",
+						"path-is-inside": "^1.0.2",
+						"pluralize": "^7.0.0",
+						"progress": "^2.0.0",
+						"regexpp": "^1.0.1",
+						"require-uncached": "^1.0.3",
+						"semver": "^5.3.0",
+						"strip-ansi": "^4.0.0",
+						"strip-json-comments": "~2.0.1",
 						"table": "4.0.2",
-						"text-table": "0.2.0"
+						"text-table": "~0.2.0"
 					}
 				},
 				"eslint-import-resolver-node": {
@@ -175,8 +175,8 @@
 					"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"resolve": "1.8.1"
+						"debug": "^2.6.9",
+						"resolve": "^1.5.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -202,8 +202,8 @@
 					"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"pkg-dir": "1.0.0"
+						"debug": "^2.6.8",
+						"pkg-dir": "^1.0.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -229,16 +229,16 @@
 					"integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
 					"dev": true,
 					"requires": {
-						"contains-path": "0.1.0",
-						"debug": "2.6.9",
+						"contains-path": "^0.1.0",
+						"debug": "^2.6.8",
 						"doctrine": "1.5.0",
-						"eslint-import-resolver-node": "0.3.2",
-						"eslint-module-utils": "2.2.0",
-						"has": "1.0.1",
-						"lodash": "4.17.4",
-						"minimatch": "3.0.4",
-						"read-pkg-up": "2.0.0",
-						"resolve": "1.8.1"
+						"eslint-import-resolver-node": "^0.3.1",
+						"eslint-module-utils": "^2.2.0",
+						"has": "^1.0.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.3",
+						"read-pkg-up": "^2.0.0",
+						"resolve": "^1.6.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -256,8 +256,8 @@
 							"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
 							"dev": true,
 							"requires": {
-								"esutils": "2.0.2",
-								"isarray": "1.0.0"
+								"esutils": "^2.0.2",
+								"isarray": "^1.0.0"
 							}
 						},
 						"ms": {
@@ -292,7 +292,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -301,7 +301,7 @@
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -312,11 +312,11 @@
 			"integrity": "sha512-GTVz+DE5NXiVYMDNC52MSEeXMHU1jDJSd+yQWutOTdSUbzgL7oi2LPK+ezIuyk9fHzGfrX8PCKUbwfIHGATv/w==",
 			"dev": true,
 			"requires": {
-				"@deloitte-digital-au/eslint-config": "3.4.0",
-				"eslint": "4.19.1",
-				"eslint-plugin-import": "2.14.0",
-				"eslint-plugin-jsx-a11y": "6.1.1",
-				"eslint-plugin-react": "7.11.1"
+				"@deloitte-digital-au/eslint-config": "^3.4.0",
+				"eslint": "^4.18.2",
+				"eslint-plugin-import": "^2.9.0",
+				"eslint-plugin-jsx-a11y": "^6.0.3",
+				"eslint-plugin-react": "^7.7.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -331,7 +331,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.3"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"aria-query": {
@@ -341,7 +341,7 @@
 					"dev": true,
 					"requires": {
 						"ast-types-flow": "0.0.7",
-						"commander": "2.18.0"
+						"commander": "^2.11.0"
 					}
 				},
 				"axobject-query": {
@@ -359,9 +359,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"commander": {
@@ -376,9 +376,9 @@
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.1",
-						"shebang-command": "1.2.0",
-						"which": "1.2.14"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -387,7 +387,7 @@
 					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
 					"dev": true,
 					"requires": {
-						"ms": "2.1.1"
+						"ms": "^2.1.1"
 					}
 				},
 				"emoji-regex": {
@@ -402,44 +402,44 @@
 					"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 					"dev": true,
 					"requires": {
-						"ajv": "5.5.2",
-						"babel-code-frame": "6.22.0",
-						"chalk": "2.4.1",
-						"concat-stream": "1.6.2",
-						"cross-spawn": "5.1.0",
-						"debug": "3.2.5",
-						"doctrine": "2.1.0",
-						"eslint-scope": "3.7.3",
-						"eslint-visitor-keys": "1.0.0",
-						"espree": "3.5.4",
-						"esquery": "1.0.1",
-						"esutils": "2.0.2",
-						"file-entry-cache": "2.0.0",
-						"functional-red-black-tree": "1.0.1",
-						"glob": "7.1.2",
-						"globals": "11.7.0",
-						"ignore": "3.3.10",
-						"imurmurhash": "0.1.4",
-						"inquirer": "3.3.0",
-						"is-resolvable": "1.1.0",
-						"js-yaml": "3.12.0",
-						"json-stable-stringify-without-jsonify": "1.0.1",
-						"levn": "0.3.0",
-						"lodash": "4.17.4",
-						"minimatch": "3.0.4",
-						"mkdirp": "0.5.1",
-						"natural-compare": "1.4.0",
-						"optionator": "0.8.2",
-						"path-is-inside": "1.0.2",
-						"pluralize": "7.0.0",
-						"progress": "2.0.0",
-						"regexpp": "1.1.0",
-						"require-uncached": "1.0.3",
-						"semver": "5.3.0",
-						"strip-ansi": "4.0.0",
-						"strip-json-comments": "2.0.1",
+						"ajv": "^5.3.0",
+						"babel-code-frame": "^6.22.0",
+						"chalk": "^2.1.0",
+						"concat-stream": "^1.6.0",
+						"cross-spawn": "^5.1.0",
+						"debug": "^3.1.0",
+						"doctrine": "^2.1.0",
+						"eslint-scope": "^3.7.1",
+						"eslint-visitor-keys": "^1.0.0",
+						"espree": "^3.5.4",
+						"esquery": "^1.0.0",
+						"esutils": "^2.0.2",
+						"file-entry-cache": "^2.0.0",
+						"functional-red-black-tree": "^1.0.1",
+						"glob": "^7.1.2",
+						"globals": "^11.0.1",
+						"ignore": "^3.3.3",
+						"imurmurhash": "^0.1.4",
+						"inquirer": "^3.0.6",
+						"is-resolvable": "^1.0.0",
+						"js-yaml": "^3.9.1",
+						"json-stable-stringify-without-jsonify": "^1.0.1",
+						"levn": "^0.3.0",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.2",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"optionator": "^0.8.2",
+						"path-is-inside": "^1.0.2",
+						"pluralize": "^7.0.0",
+						"progress": "^2.0.0",
+						"regexpp": "^1.0.1",
+						"require-uncached": "^1.0.3",
+						"semver": "^5.3.0",
+						"strip-ansi": "^4.0.0",
+						"strip-json-comments": "~2.0.1",
 						"table": "4.0.2",
-						"text-table": "0.2.0"
+						"text-table": "~0.2.0"
 					}
 				},
 				"eslint-import-resolver-node": {
@@ -448,8 +448,8 @@
 					"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"resolve": "1.8.1"
+						"debug": "^2.6.9",
+						"resolve": "^1.5.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -475,8 +475,8 @@
 					"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"pkg-dir": "1.0.0"
+						"debug": "^2.6.8",
+						"pkg-dir": "^1.0.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -502,16 +502,16 @@
 					"integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
 					"dev": true,
 					"requires": {
-						"contains-path": "0.1.0",
-						"debug": "2.6.9",
+						"contains-path": "^0.1.0",
+						"debug": "^2.6.8",
 						"doctrine": "1.5.0",
-						"eslint-import-resolver-node": "0.3.2",
-						"eslint-module-utils": "2.2.0",
-						"has": "1.0.1",
-						"lodash": "4.17.4",
-						"minimatch": "3.0.4",
-						"read-pkg-up": "2.0.0",
-						"resolve": "1.8.1"
+						"eslint-import-resolver-node": "^0.3.1",
+						"eslint-module-utils": "^2.2.0",
+						"has": "^1.0.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.3",
+						"read-pkg-up": "^2.0.0",
+						"resolve": "^1.6.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -529,8 +529,8 @@
 							"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
 							"dev": true,
 							"requires": {
-								"esutils": "2.0.2",
-								"isarray": "1.0.0"
+								"esutils": "^2.0.2",
+								"isarray": "^1.0.0"
 							}
 						},
 						"ms": {
@@ -547,14 +547,14 @@
 					"integrity": "sha512-JsxNKqa3TwmPypeXNnI75FntkUktGzI1wSa1LgNZdSOMI+B4sxnr1lSF8m8lPiz4mKiC+14ysZQM4scewUrP7A==",
 					"dev": true,
 					"requires": {
-						"aria-query": "3.0.0",
-						"array-includes": "3.0.3",
-						"ast-types-flow": "0.0.7",
-						"axobject-query": "2.0.1",
-						"damerau-levenshtein": "1.0.4",
-						"emoji-regex": "6.5.1",
-						"has": "1.0.3",
-						"jsx-ast-utils": "2.0.1"
+						"aria-query": "^3.0.0",
+						"array-includes": "^3.0.3",
+						"ast-types-flow": "^0.0.7",
+						"axobject-query": "^2.0.1",
+						"damerau-levenshtein": "^1.0.4",
+						"emoji-regex": "^6.5.1",
+						"has": "^1.0.3",
+						"jsx-ast-utils": "^2.0.1"
 					},
 					"dependencies": {
 						"has": {
@@ -563,7 +563,7 @@
 							"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 							"dev": true,
 							"requires": {
-								"function-bind": "1.1.1"
+								"function-bind": "^1.1.1"
 							}
 						}
 					}
@@ -574,11 +574,11 @@
 					"integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
 					"dev": true,
 					"requires": {
-						"array-includes": "3.0.3",
-						"doctrine": "2.1.0",
-						"has": "1.0.3",
-						"jsx-ast-utils": "2.0.1",
-						"prop-types": "15.6.2"
+						"array-includes": "^3.0.3",
+						"doctrine": "^2.1.0",
+						"has": "^1.0.3",
+						"jsx-ast-utils": "^2.0.1",
+						"prop-types": "^15.6.2"
 					},
 					"dependencies": {
 						"has": {
@@ -587,7 +587,7 @@
 							"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 							"dev": true,
 							"requires": {
-								"function-bind": "1.1.1"
+								"function-bind": "^1.1.1"
 							}
 						}
 					}
@@ -616,7 +616,7 @@
 					"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
 					"dev": true,
 					"requires": {
-						"array-includes": "3.0.3"
+						"array-includes": "^3.0.3"
 					}
 				},
 				"ms": {
@@ -631,8 +631,8 @@
 					"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
 					"dev": true,
 					"requires": {
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				},
 				"strip-ansi": {
@@ -641,7 +641,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -650,7 +650,7 @@
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -661,7 +661,7 @@
 			"integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
 			"dev": true,
 			"requires": {
-				"mime-types": "2.1.15",
+				"mime-types": "~2.1.11",
 				"negotiator": "0.6.1"
 			}
 		},
@@ -677,7 +677,7 @@
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"requires": {
-				"acorn": "3.3.0"
+				"acorn": "^3.0.4"
 			},
 			"dependencies": {
 				"acorn": {
@@ -700,10 +700,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ajv-keywords": {
@@ -718,9 +718,9 @@
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2",
-				"longest": "1.0.1",
-				"repeat-string": "1.6.1"
+				"kind-of": "^3.0.2",
+				"longest": "^1.0.1",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"amdefine": {
@@ -753,8 +753,8 @@
 			"integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"micromatch": "2.3.11"
+				"arrify": "^1.0.0",
+				"micromatch": "^2.1.5"
 			}
 		},
 		"argparse": {
@@ -763,7 +763,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"aria-query": {
@@ -773,7 +773,7 @@
 			"dev": true,
 			"requires": {
 				"ast-types-flow": "0.0.7",
-				"commander": "2.18.0"
+				"commander": "^2.11.0"
 			},
 			"dependencies": {
 				"commander": {
@@ -790,7 +790,7 @@
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "1.0.3"
+				"arr-flatten": "^1.0.1"
 			}
 		},
 		"arr-flatten": {
@@ -805,8 +805,8 @@
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.7.0"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.7.0"
 			}
 		},
 		"array-slice": {
@@ -821,7 +821,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
 			}
 		},
 		"array-uniq": {
@@ -896,21 +896,21 @@
 			"integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.25.0",
-				"babel-polyfill": "6.23.0",
-				"babel-register": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"chokidar": "1.7.0",
-				"commander": "2.10.0",
-				"convert-source-map": "1.5.0",
-				"fs-readdir-recursive": "1.0.0",
-				"glob": "7.1.2",
-				"lodash": "4.17.4",
-				"output-file-sync": "1.1.2",
-				"path-is-absolute": "1.0.1",
-				"slash": "1.0.0",
-				"source-map": "0.5.6",
-				"v8flags": "2.1.1"
+				"babel-core": "^6.24.1",
+				"babel-polyfill": "^6.23.0",
+				"babel-register": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"chokidar": "^1.6.1",
+				"commander": "^2.8.1",
+				"convert-source-map": "^1.1.0",
+				"fs-readdir-recursive": "^1.0.0",
+				"glob": "^7.0.0",
+				"lodash": "^4.2.0",
+				"output-file-sync": "^1.1.0",
+				"path-is-absolute": "^1.0.0",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.0",
+				"v8flags": "^2.0.10"
 			}
 		},
 		"babel-code-frame": {
@@ -919,9 +919,9 @@
 			"integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.1"
+				"chalk": "^1.1.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
 			}
 		},
 		"babel-core": {
@@ -930,25 +930,25 @@
 			"integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.22.0",
-				"babel-generator": "6.25.0",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4",
-				"convert-source-map": "1.5.0",
-				"debug": "2.6.8",
-				"json5": "0.5.1",
-				"lodash": "4.17.4",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.7",
-				"slash": "1.0.0",
-				"source-map": "0.5.6"
+				"babel-code-frame": "^6.22.0",
+				"babel-generator": "^6.25.0",
+				"babel-helpers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-register": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.25.0",
+				"babel-traverse": "^6.25.0",
+				"babel-types": "^6.25.0",
+				"babylon": "^6.17.2",
+				"convert-source-map": "^1.1.0",
+				"debug": "^2.1.1",
+				"json5": "^0.5.0",
+				"lodash": "^4.2.0",
+				"minimatch": "^3.0.2",
+				"path-is-absolute": "^1.0.0",
+				"private": "^0.1.6",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.0"
 			}
 		},
 		"babel-eslint": {
@@ -957,10 +957,10 @@
 			"integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.22.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4"
+				"babel-code-frame": "^6.22.0",
+				"babel-traverse": "^6.23.1",
+				"babel-types": "^6.23.0",
+				"babylon": "^6.17.0"
 			}
 		},
 		"babel-generator": {
@@ -969,14 +969,14 @@
 			"integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
 			"dev": true,
 			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.4",
-				"source-map": "0.5.6",
-				"trim-right": "1.0.1"
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.25.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.2.0",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
 			}
 		},
 		"babel-helper-bindify-decorators": {
@@ -985,9 +985,9 @@
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
@@ -996,9 +996,9 @@
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0"
+				"babel-helper-explode-assignable-expression": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-builder-react-jsx": {
@@ -1007,9 +1007,9 @@
 			"integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0",
-				"esutils": "2.0.2"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1",
+				"esutils": "^2.0.0"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -1018,10 +1018,10 @@
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-define-map": {
@@ -1030,10 +1030,10 @@
 			"integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0",
-				"lodash": "4.17.4"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1",
+				"lodash": "^4.2.0"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -1042,9 +1042,9 @@
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-explode-class": {
@@ -1053,10 +1053,10 @@
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
 			"dev": true,
 			"requires": {
-				"babel-helper-bindify-decorators": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-bindify-decorators": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-function-name": {
@@ -1065,11 +1065,11 @@
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"dev": true,
 			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -1078,8 +1078,8 @@
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -1088,8 +1088,8 @@
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -1098,8 +1098,8 @@
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-regex": {
@@ -1108,9 +1108,9 @@
 			"integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0",
-				"lodash": "4.17.4"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1",
+				"lodash": "^4.2.0"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -1119,11 +1119,11 @@
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -1132,12 +1132,12 @@
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"dev": true,
 			"requires": {
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helpers": {
@@ -1146,8 +1146,8 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-loader": {
@@ -1156,10 +1156,10 @@
 			"integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "0.1.1",
-				"loader-utils": "0.2.17",
-				"mkdirp": "0.5.1",
-				"object-assign": "4.1.1"
+				"find-cache-dir": "^0.1.1",
+				"loader-utils": "^0.2.16",
+				"mkdirp": "^0.5.1",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"babel-messages": {
@@ -1168,7 +1168,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-add-module-exports": {
@@ -1183,7 +1183,7 @@
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-syntax-async-functions": {
@@ -1276,9 +1276,9 @@
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-generators": "6.13.0",
-				"babel-runtime": "6.23.0"
+				"babel-helper-remap-async-to-generator": "^6.24.1",
+				"babel-plugin-syntax-async-generators": "^6.5.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-async-to-generator": {
@@ -1287,9 +1287,9 @@
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.23.0"
+				"babel-helper-remap-async-to-generator": "^6.24.1",
+				"babel-plugin-syntax-async-functions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-class-constructor-call": {
@@ -1298,9 +1298,9 @@
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-class-constructor-call": "6.18.0",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0"
+				"babel-plugin-syntax-class-constructor-call": "^6.18.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-class-properties": {
@@ -1309,10 +1309,10 @@
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-plugin-syntax-class-properties": "6.13.0",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-plugin-syntax-class-properties": "^6.8.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-decorators": {
@@ -1321,11 +1321,11 @@
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-class": "6.24.1",
-				"babel-plugin-syntax-decorators": "6.13.0",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-explode-class": "^6.24.1",
+				"babel-plugin-syntax-decorators": "^6.13.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-do-expressions": {
@@ -1334,8 +1334,8 @@
 			"integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-do-expressions": "6.13.0",
-				"babel-runtime": "6.23.0"
+				"babel-plugin-syntax-do-expressions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -1344,7 +1344,7 @@
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1353,7 +1353,7 @@
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -1362,11 +1362,11 @@
 			"integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"lodash": "4.17.4"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1",
+				"lodash": "^4.2.0"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -1375,15 +1375,15 @@
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-define-map": "6.24.1",
-				"babel-helper-function-name": "6.24.1",
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-define-map": "^6.24.1",
+				"babel-helper-function-name": "^6.24.1",
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -1392,8 +1392,8 @@
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -1402,7 +1402,7 @@
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
@@ -1411,8 +1411,8 @@
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -1421,7 +1421,7 @@
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -1430,9 +1430,9 @@
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -1441,7 +1441,7 @@
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
@@ -1450,9 +1450,9 @@
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0"
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -1461,10 +1461,10 @@
 			"integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-plugin-transform-strict-mode": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
@@ -1473,9 +1473,9 @@
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
@@ -1484,9 +1484,9 @@
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0"
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -1495,8 +1495,8 @@
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"dev": true,
 			"requires": {
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-runtime": "6.23.0"
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -1505,12 +1505,12 @@
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"dev": true,
 			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-call-delegate": "^6.24.1",
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -1519,8 +1519,8 @@
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -1529,7 +1529,7 @@
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -1538,9 +1538,9 @@
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -1549,7 +1549,7 @@
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
@@ -1558,7 +1558,7 @@
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -1567,9 +1567,9 @@
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "6.24.1",
-				"babel-runtime": "6.23.0",
-				"regexpu-core": "2.0.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"regexpu-core": "^2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -1578,9 +1578,9 @@
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.23.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-export-extensions": {
@@ -1589,8 +1589,8 @@
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-export-extensions": "6.13.0",
-				"babel-runtime": "6.23.0"
+				"babel-plugin-syntax-export-extensions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -1599,8 +1599,8 @@
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-flow": "6.18.0",
-				"babel-runtime": "6.23.0"
+				"babel-plugin-syntax-flow": "^6.18.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-function-bind": {
@@ -1609,8 +1609,8 @@
 			"integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-function-bind": "6.13.0",
-				"babel-runtime": "6.23.0"
+				"babel-plugin-syntax-function-bind": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -1619,8 +1619,8 @@
 			"integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"babel-runtime": "6.23.0"
+				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-display-name": {
@@ -1629,7 +1629,7 @@
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx": {
@@ -1638,9 +1638,9 @@
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-react-jsx": "6.24.1",
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.23.0"
+				"babel-helper-builder-react-jsx": "^6.24.1",
+				"babel-plugin-syntax-jsx": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-self": {
@@ -1649,8 +1649,8 @@
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.23.0"
+				"babel-plugin-syntax-jsx": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-source": {
@@ -1659,8 +1659,8 @@
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.23.0"
+				"babel-plugin-syntax-jsx": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -1678,8 +1678,8 @@
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-polyfill": {
@@ -1688,9 +1688,9 @@
 			"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"core-js": "2.4.1",
-				"regenerator-runtime": "0.10.5"
+				"babel-runtime": "^6.22.0",
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.10.0"
 			},
 			"dependencies": {
 				"core-js": {
@@ -1707,30 +1707,30 @@
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.24.1",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.24.1"
+				"babel-plugin-check-es2015-constants": "^6.22.0",
+				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+				"babel-plugin-transform-es2015-classes": "^6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "^6.22.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+				"babel-plugin-transform-es2015-for-of": "^6.22.0",
+				"babel-plugin-transform-es2015-function-name": "^6.24.1",
+				"babel-plugin-transform-es2015-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+				"babel-plugin-transform-es2015-object-super": "^6.24.1",
+				"babel-plugin-transform-es2015-parameters": "^6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-spread": "^6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+				"babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+				"babel-plugin-transform-regenerator": "^6.24.1"
 			}
 		},
 		"babel-preset-flow": {
@@ -1739,7 +1739,7 @@
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-flow-strip-types": "6.22.0"
+				"babel-plugin-transform-flow-strip-types": "^6.22.0"
 			}
 		},
 		"babel-preset-react": {
@@ -1748,12 +1748,12 @@
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-plugin-transform-react-display-name": "6.25.0",
-				"babel-plugin-transform-react-jsx": "6.24.1",
-				"babel-plugin-transform-react-jsx-self": "6.22.0",
-				"babel-plugin-transform-react-jsx-source": "6.22.0",
-				"babel-preset-flow": "6.23.0"
+				"babel-plugin-syntax-jsx": "^6.3.13",
+				"babel-plugin-transform-react-display-name": "^6.23.0",
+				"babel-plugin-transform-react-jsx": "^6.24.1",
+				"babel-plugin-transform-react-jsx-self": "^6.22.0",
+				"babel-plugin-transform-react-jsx-source": "^6.22.0",
+				"babel-preset-flow": "^6.23.0"
 			}
 		},
 		"babel-preset-stage-0": {
@@ -1762,9 +1762,9 @@
 			"integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-do-expressions": "6.22.0",
-				"babel-plugin-transform-function-bind": "6.22.0",
-				"babel-preset-stage-1": "6.24.1"
+				"babel-plugin-transform-do-expressions": "^6.22.0",
+				"babel-plugin-transform-function-bind": "^6.22.0",
+				"babel-preset-stage-1": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-1": {
@@ -1773,9 +1773,9 @@
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-class-constructor-call": "6.24.1",
-				"babel-plugin-transform-export-extensions": "6.22.0",
-				"babel-preset-stage-2": "6.24.1"
+				"babel-plugin-transform-class-constructor-call": "^6.24.1",
+				"babel-plugin-transform-export-extensions": "^6.22.0",
+				"babel-preset-stage-2": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-2": {
@@ -1784,10 +1784,10 @@
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-dynamic-import": "6.18.0",
-				"babel-plugin-transform-class-properties": "6.24.1",
-				"babel-plugin-transform-decorators": "6.24.1",
-				"babel-preset-stage-3": "6.24.1"
+				"babel-plugin-syntax-dynamic-import": "^6.18.0",
+				"babel-plugin-transform-class-properties": "^6.24.1",
+				"babel-plugin-transform-decorators": "^6.24.1",
+				"babel-preset-stage-3": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-3": {
@@ -1796,11 +1796,11 @@
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-generator-functions": "6.24.1",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-object-rest-spread": "6.23.0"
+				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+				"babel-plugin-transform-async-generator-functions": "^6.24.1",
+				"babel-plugin-transform-async-to-generator": "^6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "^6.24.1",
+				"babel-plugin-transform-object-rest-spread": "^6.22.0"
 			}
 		},
 		"babel-register": {
@@ -1809,13 +1809,13 @@
 			"integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.25.0",
-				"babel-runtime": "6.23.0",
-				"core-js": "2.4.1",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.4",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.15"
+				"babel-core": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"core-js": "^2.4.0",
+				"home-or-tmp": "^2.0.0",
+				"lodash": "^4.2.0",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.4.2"
 			},
 			"dependencies": {
 				"core-js": {
@@ -1832,8 +1832,8 @@
 			"integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
 			"dev": true,
 			"requires": {
-				"core-js": "2.4.1",
-				"regenerator-runtime": "0.10.5"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.10.0"
 			},
 			"dependencies": {
 				"core-js": {
@@ -1850,11 +1850,11 @@
 			"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4",
-				"lodash": "4.17.4"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.25.0",
+				"babel-types": "^6.25.0",
+				"babylon": "^6.17.2",
+				"lodash": "^4.2.0"
 			}
 		},
 		"babel-traverse": {
@@ -1863,15 +1863,15 @@
 			"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.22.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4",
-				"debug": "2.6.8",
-				"globals": "9.18.0",
-				"invariant": "2.2.2",
-				"lodash": "4.17.4"
+				"babel-code-frame": "^6.22.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.25.0",
+				"babylon": "^6.17.2",
+				"debug": "^2.2.0",
+				"globals": "^9.0.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.2.0"
 			}
 		},
 		"babel-types": {
@@ -1880,10 +1880,10 @@
 			"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.4",
-				"to-fast-properties": "1.0.3"
+				"babel-runtime": "^6.22.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.2.0",
+				"to-fast-properties": "^1.0.1"
 			}
 		},
 		"babylon": {
@@ -1901,7 +1901,8 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base64-arraybuffer": {
 			"version": "0.1.5",
@@ -1961,15 +1962,15 @@
 			"dev": true,
 			"requires": {
 				"bytes": "2.4.0",
-				"content-type": "1.0.2",
+				"content-type": "~1.0.2",
 				"debug": "2.6.7",
-				"depd": "1.1.0",
-				"http-errors": "1.6.1",
+				"depd": "~1.1.0",
+				"http-errors": "~1.6.1",
 				"iconv-lite": "0.4.15",
-				"on-finished": "2.3.0",
+				"on-finished": "~2.3.0",
 				"qs": "6.4.0",
-				"raw-body": "2.2.0",
-				"type-is": "1.6.15"
+				"raw-body": "~2.2.0",
+				"type-is": "~1.6.15"
 			},
 			"dependencies": {
 				"debug": {
@@ -1993,8 +1994,9 @@
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -2004,9 +2006,9 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
 			}
 		},
 		"browserify-aes": {
@@ -2015,7 +2017,7 @@
 			"integrity": "sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "^2.0.1"
 			}
 		},
 		"browserify-zlib": {
@@ -2024,7 +2026,7 @@
 			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
 			"dev": true,
 			"requires": {
-				"pako": "0.2.9"
+				"pako": "~0.2.0"
 			}
 		},
 		"buffer": {
@@ -2033,9 +2035,9 @@
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"dev": true,
 			"requires": {
-				"base64-js": "1.2.1",
-				"ieee754": "1.1.8",
-				"isarray": "1.0.0"
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4",
+				"isarray": "^1.0.0"
 			}
 		},
 		"buffer-from": {
@@ -2047,7 +2049,8 @@
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
 		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
@@ -2067,7 +2070,7 @@
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "0.2.0"
+				"callsites": "^0.2.0"
 			}
 		},
 		"callsite": {
@@ -2094,8 +2097,8 @@
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
 			"dev": true,
 			"requires": {
-				"align-text": "0.1.4",
-				"lazy-cache": "1.0.4"
+				"align-text": "^0.1.3",
+				"lazy-cache": "^1.0.3"
 			}
 		},
 		"chalk": {
@@ -2104,11 +2107,11 @@
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
 			}
 		},
 		"chardet": {
@@ -2123,15 +2126,15 @@
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
 			"dev": true,
 			"requires": {
-				"anymatch": "1.3.0",
-				"async-each": "1.0.1",
-				"fsevents": "1.2.4",
-				"glob-parent": "2.0.0",
-				"inherits": "2.0.3",
-				"is-binary-path": "1.0.1",
-				"is-glob": "2.0.1",
-				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0"
+				"anymatch": "^1.3.0",
+				"async-each": "^1.0.0",
+				"fsevents": "^1.0.0",
+				"glob-parent": "^2.0.0",
+				"inherits": "^2.0.1",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^2.0.0",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.0.0"
 			}
 		},
 		"circular-json": {
@@ -2146,7 +2149,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "2.0.0"
+				"restore-cursor": "^2.0.0"
 			}
 		},
 		"cli-width": {
@@ -2161,8 +2164,8 @@
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
 			"dev": true,
 			"requires": {
-				"center-align": "0.1.3",
-				"right-align": "0.1.3",
+				"center-align": "^0.1.1",
+				"right-align": "^0.1.1",
 				"wordwrap": "0.0.2"
 			},
 			"dependencies": {
@@ -2213,7 +2216,7 @@
 			"integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.4"
+				"lodash": "^4.5.0"
 			}
 		},
 		"commander": {
@@ -2222,7 +2225,7 @@
 			"integrity": "sha512-q/r9trjmuikWDRJNTBHAVnWhuU6w+z80KgBq7j9YDclik5E7X4xi0KnlZBNFA1zOQ+SH/vHMWd2mC9QTOz7GpA==",
 			"dev": true,
 			"requires": {
-				"graceful-readlink": "1.0.1"
+				"graceful-readlink": ">= 1.0.0"
 			}
 		},
 		"commondir": {
@@ -2252,7 +2255,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -2260,10 +2264,10 @@
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.1",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.2",
-				"typedarray": "0.0.6"
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
 			}
 		},
 		"connect": {
@@ -2274,7 +2278,7 @@
 			"requires": {
 				"debug": "2.6.7",
 				"finalhandler": "1.0.3",
-				"parseurl": "1.3.1",
+				"parseurl": "~1.3.1",
 				"utils-merge": "1.0.0"
 			},
 			"dependencies": {
@@ -2295,7 +2299,7 @@
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"dev": true,
 			"requires": {
-				"date-now": "0.1.4"
+				"date-now": "^0.1.4"
 			}
 		},
 		"constants-browserify": {
@@ -2307,7 +2311,8 @@
 		"contains-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"dev": true
 		},
 		"content-type": {
 			"version": "1.0.2",
@@ -2345,8 +2350,8 @@
 			"integrity": "sha1-8oO0A56nWa2pq36YetO92yQbeaY=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "3.0.1",
-				"lodash.assign": "3.2.0"
+				"cross-spawn": "^3.0.1",
+				"lodash.assign": "^3.2.0"
 			}
 		},
 		"cross-spawn": {
@@ -2355,8 +2360,8 @@
 			"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.1",
-				"which": "1.2.14"
+				"lru-cache": "^4.0.1",
+				"which": "^1.2.9"
 			}
 		},
 		"crypto-browserify": {
@@ -2393,6 +2398,7 @@
 			"version": "2.6.8",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
 			"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -2415,8 +2421,8 @@
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
+				"foreach": "^2.0.5",
+				"object-keys": "^1.0.8"
 			}
 		},
 		"del": {
@@ -2425,13 +2431,13 @@
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 			"dev": true,
 			"requires": {
-				"globby": "5.0.0",
-				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.1",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"rimraf": "2.6.1"
+				"globby": "^5.0.0",
+				"is-path-cwd": "^1.0.0",
+				"is-path-in-cwd": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"rimraf": "^2.2.8"
 			}
 		},
 		"depd": {
@@ -2446,7 +2452,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"di": {
@@ -2461,7 +2467,7 @@
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
-				"esutils": "2.0.2"
+				"esutils": "^2.0.2"
 			}
 		},
 		"dom-serialize": {
@@ -2470,10 +2476,10 @@
 			"integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
 			"dev": true,
 			"requires": {
-				"custom-event": "1.0.1",
-				"ent": "2.2.0",
-				"extend": "3.0.1",
-				"void-elements": "2.0.1"
+				"custom-event": "~1.0.0",
+				"ent": "~2.2.0",
+				"extend": "^3.0.0",
+				"void-elements": "^2.0.0"
 			}
 		},
 		"domain-browser": {
@@ -2512,7 +2518,7 @@
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"dev": true,
 			"requires": {
-				"iconv-lite": "0.4.18"
+				"iconv-lite": "~0.4.13"
 			}
 		},
 		"engine.io": {
@@ -2609,9 +2615,9 @@
 			"integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"memory-fs": "0.2.0",
-				"tapable": "0.1.10"
+				"graceful-fs": "^4.1.2",
+				"memory-fs": "^0.2.0",
+				"tapable": "^0.1.8"
 			},
 			"dependencies": {
 				"memory-fs": {
@@ -2634,15 +2640,16 @@
 			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
 			"dev": true,
 			"requires": {
-				"prr": "0.0.0"
+				"prr": "~0.0.0"
 			}
 		},
 		"error-ex": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"dev": true,
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -2651,10 +2658,10 @@
 			"integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "1.1.1",
-				"function-bind": "1.1.0",
-				"is-callable": "1.1.3",
-				"is-regex": "1.0.4"
+				"es-to-primitive": "^1.1.1",
+				"function-bind": "^1.1.0",
+				"is-callable": "^1.1.3",
+				"is-regex": "^1.0.3"
 			}
 		},
 		"es-to-primitive": {
@@ -2663,9 +2670,9 @@
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"dev": true,
 			"requires": {
-				"is-callable": "1.1.3",
-				"is-date-object": "1.0.1",
-				"is-symbol": "1.0.1"
+				"is-callable": "^1.1.1",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.1"
 			}
 		},
 		"escape-html": {
@@ -2686,44 +2693,44 @@
 			"integrity": "sha512-hgrDtGWz368b7Wqf+v1Z69O3ZebNR0+GA7PtDdbmuz4rInFVUV9uw7whjZEiWyLzCjVb5Rs5WRN1TAS6eo7AYA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0",
-				"ajv": "6.5.4",
-				"chalk": "2.4.1",
-				"cross-spawn": "6.0.5",
-				"debug": "4.0.1",
-				"doctrine": "2.1.0",
-				"eslint-scope": "4.0.0",
-				"eslint-utils": "1.3.1",
-				"eslint-visitor-keys": "1.0.0",
-				"espree": "4.0.0",
-				"esquery": "1.0.1",
-				"esutils": "2.0.2",
-				"file-entry-cache": "2.0.0",
-				"functional-red-black-tree": "1.0.1",
-				"glob": "7.1.2",
-				"globals": "11.7.0",
-				"ignore": "4.0.6",
-				"imurmurhash": "0.1.4",
-				"inquirer": "6.2.0",
-				"is-resolvable": "1.1.0",
-				"js-yaml": "3.12.0",
-				"json-stable-stringify-without-jsonify": "1.0.1",
-				"levn": "0.3.0",
-				"lodash": "4.17.11",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"optionator": "0.8.2",
-				"path-is-inside": "1.0.2",
-				"pluralize": "7.0.0",
-				"progress": "2.0.0",
-				"regexpp": "2.0.0",
-				"require-uncached": "1.0.3",
-				"semver": "5.5.1",
-				"strip-ansi": "4.0.0",
-				"strip-json-comments": "2.0.1",
-				"table": "4.0.3",
-				"text-table": "0.2.0"
+				"@babel/code-frame": "^7.0.0",
+				"ajv": "^6.5.3",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.5",
+				"debug": "^4.0.1",
+				"doctrine": "^2.1.0",
+				"eslint-scope": "^4.0.0",
+				"eslint-utils": "^1.3.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^4.0.0",
+				"esquery": "^1.0.1",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^2.0.0",
+				"functional-red-black-tree": "^1.0.1",
+				"glob": "^7.1.2",
+				"globals": "^11.7.0",
+				"ignore": "^4.0.6",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^6.1.0",
+				"is-resolvable": "^1.1.0",
+				"js-yaml": "^3.12.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.5",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"path-is-inside": "^1.0.2",
+				"pluralize": "^7.0.0",
+				"progress": "^2.0.0",
+				"regexpp": "^2.0.0",
+				"require-uncached": "^1.0.3",
+				"semver": "^5.5.1",
+				"strip-ansi": "^4.0.0",
+				"strip-json-comments": "^2.0.1",
+				"table": "^4.0.3",
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
 				"acorn-jsx": {
@@ -2732,7 +2739,7 @@
 					"integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
 					"dev": true,
 					"requires": {
-						"acorn": "5.7.3"
+						"acorn": "^5.0.3"
 					}
 				},
 				"ajv": {
@@ -2741,10 +2748,10 @@
 					"integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "2.0.1",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.4.1",
-						"uri-js": "4.2.2"
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
 					}
 				},
 				"ajv-keywords": {
@@ -2765,7 +2772,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.3"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -2774,9 +2781,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"chardet": {
@@ -2791,11 +2798,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "1.0.5",
-						"path-key": "2.0.1",
-						"semver": "5.5.1",
-						"shebang-command": "1.2.0",
-						"which": "1.2.14"
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -2804,7 +2811,7 @@
 					"integrity": "sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==",
 					"dev": true,
 					"requires": {
-						"ms": "2.1.1"
+						"ms": "^2.1.1"
 					}
 				},
 				"eslint-scope": {
@@ -2813,8 +2820,8 @@
 					"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
 					"dev": true,
 					"requires": {
-						"esrecurse": "4.2.1",
-						"estraverse": "4.2.0"
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
 					}
 				},
 				"espree": {
@@ -2823,8 +2830,8 @@
 					"integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
 					"dev": true,
 					"requires": {
-						"acorn": "5.7.3",
-						"acorn-jsx": "4.1.1"
+						"acorn": "^5.6.0",
+						"acorn-jsx": "^4.1.1"
 					}
 				},
 				"external-editor": {
@@ -2833,9 +2840,9 @@
 					"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
 					"dev": true,
 					"requires": {
-						"chardet": "0.7.0",
-						"iconv-lite": "0.4.24",
-						"tmp": "0.0.33"
+						"chardet": "^0.7.0",
+						"iconv-lite": "^0.4.24",
+						"tmp": "^0.0.33"
 					}
 				},
 				"fast-deep-equal": {
@@ -2862,7 +2869,7 @@
 					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 					"dev": true,
 					"requires": {
-						"safer-buffer": "2.1.2"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"ignore": {
@@ -2877,19 +2884,19 @@
 					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.1.0",
-						"chalk": "2.4.1",
-						"cli-cursor": "2.1.0",
-						"cli-width": "2.2.0",
-						"external-editor": "3.0.3",
-						"figures": "2.0.0",
-						"lodash": "4.17.11",
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^3.0.0",
+						"figures": "^2.0.0",
+						"lodash": "^4.17.10",
 						"mute-stream": "0.0.7",
-						"run-async": "2.3.0",
-						"rxjs": "6.3.3",
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"through": "2.3.8"
+						"run-async": "^2.2.0",
+						"rxjs": "^6.1.0",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
 					}
 				},
 				"json-schema-traverse": {
@@ -2928,7 +2935,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -2937,7 +2944,7 @@
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"table": {
@@ -2946,12 +2953,12 @@
 					"integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
 					"dev": true,
 					"requires": {
-						"ajv": "6.5.4",
-						"ajv-keywords": "3.2.0",
-						"chalk": "2.4.1",
-						"lodash": "4.17.11",
+						"ajv": "^6.0.1",
+						"ajv-keywords": "^3.0.0",
+						"chalk": "^2.1.0",
+						"lodash": "^4.17.4",
 						"slice-ansi": "1.0.0",
-						"string-width": "2.1.1"
+						"string-width": "^2.1.1"
 					}
 				},
 				"tmp": {
@@ -2960,7 +2967,7 @@
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 					"dev": true,
 					"requires": {
-						"os-tmpdir": "1.0.2"
+						"os-tmpdir": "~1.0.2"
 					}
 				}
 			}
@@ -2969,15 +2976,17 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
 			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"resolve": "1.8.1"
+				"debug": "^2.6.9",
+				"resolve": "^1.5.0"
 			},
 			"dependencies": {
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -2988,35 +2997,38 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
 			"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+			"dev": true,
 			"requires": {
-				"debug": "2.6.8",
-				"pkg-dir": "1.0.0"
+				"debug": "^2.6.8",
+				"pkg-dir": "^1.0.0"
 			}
 		},
 		"eslint-plugin-import": {
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
 			"integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+			"dev": true,
 			"requires": {
-				"contains-path": "0.1.0",
-				"debug": "2.6.8",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.8",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "0.3.2",
-				"eslint-module-utils": "2.2.0",
-				"has": "1.0.1",
-				"lodash": "4.17.4",
-				"minimatch": "3.0.4",
-				"read-pkg-up": "2.0.0",
-				"resolve": "1.8.1"
+				"eslint-import-resolver-node": "^0.3.1",
+				"eslint-module-utils": "^2.2.0",
+				"has": "^1.0.1",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.3",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.6.0"
 			},
 			"dependencies": {
 				"doctrine": {
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
 					"requires": {
-						"esutils": "2.0.2",
-						"isarray": "1.0.0"
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
 					}
 				}
 			}
@@ -3033,14 +3045,14 @@
 			"integrity": "sha512-JsxNKqa3TwmPypeXNnI75FntkUktGzI1wSa1LgNZdSOMI+B4sxnr1lSF8m8lPiz4mKiC+14ysZQM4scewUrP7A==",
 			"dev": true,
 			"requires": {
-				"aria-query": "3.0.0",
-				"array-includes": "3.0.3",
-				"ast-types-flow": "0.0.7",
-				"axobject-query": "2.0.1",
-				"damerau-levenshtein": "1.0.4",
-				"emoji-regex": "6.5.1",
-				"has": "1.0.3",
-				"jsx-ast-utils": "2.0.1"
+				"aria-query": "^3.0.0",
+				"array-includes": "^3.0.3",
+				"ast-types-flow": "^0.0.7",
+				"axobject-query": "^2.0.1",
+				"damerau-levenshtein": "^1.0.4",
+				"emoji-regex": "^6.5.1",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.0.1"
 			},
 			"dependencies": {
 				"function-bind": {
@@ -3055,7 +3067,7 @@
 					"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 					"dev": true,
 					"requires": {
-						"function-bind": "1.1.1"
+						"function-bind": "^1.1.1"
 					}
 				}
 			}
@@ -3066,11 +3078,11 @@
 			"integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
 			"dev": true,
 			"requires": {
-				"array-includes": "3.0.3",
-				"doctrine": "2.1.0",
-				"has": "1.0.3",
-				"jsx-ast-utils": "2.0.1",
-				"prop-types": "15.6.2"
+				"array-includes": "^3.0.3",
+				"doctrine": "^2.1.0",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.0.1",
+				"prop-types": "^15.6.2"
 			},
 			"dependencies": {
 				"function-bind": {
@@ -3085,7 +3097,7 @@
 					"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 					"dev": true,
 					"requires": {
-						"function-bind": "1.1.1"
+						"function-bind": "^1.1.1"
 					}
 				},
 				"prop-types": {
@@ -3094,8 +3106,8 @@
 					"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
 					"dev": true,
 					"requires": {
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				}
 			}
@@ -3106,8 +3118,8 @@
 			"integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
 			"dev": true,
 			"requires": {
-				"esrecurse": "4.2.1",
-				"estraverse": "4.2.0"
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"eslint-utils": {
@@ -3128,8 +3140,8 @@
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.7.3",
-				"acorn-jsx": "3.0.1"
+				"acorn": "^5.5.0",
+				"acorn-jsx": "^3.0.0"
 			}
 		},
 		"esprima": {
@@ -3144,7 +3156,7 @@
 			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.0.0"
 			}
 		},
 		"esrecurse": {
@@ -3153,7 +3165,7 @@
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.1.0"
 			}
 		},
 		"estraverse": {
@@ -3165,7 +3177,8 @@
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"eventemitter3": {
 			"version": "1.2.0",
@@ -3185,9 +3198,9 @@
 			"integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
 			"dev": true,
 			"requires": {
-				"array-slice": "0.2.3",
-				"array-unique": "0.2.1",
-				"braces": "0.1.5"
+				"array-slice": "^0.2.3",
+				"array-unique": "^0.2.1",
+				"braces": "^0.1.2"
 			},
 			"dependencies": {
 				"braces": {
@@ -3196,7 +3209,7 @@
 					"integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
 					"dev": true,
 					"requires": {
-						"expand-range": "0.1.1"
+						"expand-range": "^0.1.0"
 					}
 				},
 				"expand-range": {
@@ -3205,8 +3218,8 @@
 					"integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
 					"dev": true,
 					"requires": {
-						"is-number": "0.1.1",
-						"repeat-string": "0.2.2"
+						"is-number": "^0.1.1",
+						"repeat-string": "^0.2.2"
 					}
 				},
 				"is-number": {
@@ -3229,7 +3242,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "0.1.1"
+				"is-posix-bracket": "^0.1.0"
 			}
 		},
 		"expand-range": {
@@ -3238,7 +3251,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "2.2.3"
+				"fill-range": "^2.1.0"
 			}
 		},
 		"extend": {
@@ -3253,9 +3266,9 @@
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"dev": true,
 			"requires": {
-				"chardet": "0.4.2",
-				"iconv-lite": "0.4.18",
-				"tmp": "0.0.33"
+				"chardet": "^0.4.0",
+				"iconv-lite": "^0.4.17",
+				"tmp": "^0.0.33"
 			},
 			"dependencies": {
 				"tmp": {
@@ -3264,7 +3277,7 @@
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 					"dev": true,
 					"requires": {
-						"os-tmpdir": "1.0.2"
+						"os-tmpdir": "~1.0.2"
 					}
 				}
 			}
@@ -3275,7 +3288,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"fast-deep-equal": {
@@ -3302,13 +3315,13 @@
 			"integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
 			"dev": true,
 			"requires": {
-				"core-js": "1.2.7",
-				"isomorphic-fetch": "2.2.1",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"promise": "7.3.1",
-				"setimmediate": "1.0.5",
-				"ua-parser-js": "0.7.13"
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.9"
 			}
 		},
 		"figures": {
@@ -3317,7 +3330,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -3326,8 +3339,8 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "1.3.0",
-				"object-assign": "4.1.1"
+				"flat-cache": "^1.2.1",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"filename-regex": {
@@ -3342,11 +3355,11 @@
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 			"dev": true,
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "1.1.7",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^1.1.3",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"finalhandler": {
@@ -3356,12 +3369,12 @@
 			"dev": true,
 			"requires": {
 				"debug": "2.6.7",
-				"encodeurl": "1.0.1",
-				"escape-html": "1.0.3",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.1",
-				"statuses": "1.3.1",
-				"unpipe": "1.0.0"
+				"encodeurl": "~1.0.1",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.1",
+				"statuses": "~1.3.1",
+				"unpipe": "~1.0.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -3381,18 +3394,19 @@
 			"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
 			"dev": true,
 			"requires": {
-				"commondir": "1.0.1",
-				"mkdirp": "0.5.1",
-				"pkg-dir": "1.0.0"
+				"commondir": "^1.0.1",
+				"mkdirp": "^0.5.1",
+				"pkg-dir": "^1.0.0"
 			}
 		},
 		"find-up": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"dev": true,
 			"requires": {
-				"path-exists": "2.1.0",
-				"pinkie-promise": "2.0.1"
+				"path-exists": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"flat-cache": {
@@ -3401,10 +3415,10 @@
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"dev": true,
 			"requires": {
-				"circular-json": "0.3.3",
-				"del": "2.2.2",
-				"graceful-fs": "4.1.11",
-				"write": "0.2.1"
+				"circular-json": "^0.3.1",
+				"del": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"write": "^0.2.1"
 			}
 		},
 		"for-in": {
@@ -3419,7 +3433,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
 		},
 		"foreach": {
@@ -3434,7 +3448,7 @@
 			"integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
 			"dev": true,
 			"requires": {
-				"null-check": "1.0.0"
+				"null-check": "^1.0.0"
 			}
 		},
 		"fs-readdir-recursive": {
@@ -3456,8 +3470,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "2.11.1",
-				"node-pre-gyp": "0.10.0"
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -3483,8 +3497,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.3.6"
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
 					}
 				},
 				"balanced-match": {
@@ -3497,7 +3511,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -3561,7 +3575,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "2.2.4"
+						"minipass": "^2.2.1"
 					}
 				},
 				"fs.realpath": {
@@ -3576,14 +3590,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "1.2.0",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
 					}
 				},
 				"glob": {
@@ -3592,12 +3606,12 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-unicode": {
@@ -3612,7 +3626,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "2.1.2"
+						"safer-buffer": "^2.1.0"
 					}
 				},
 				"ignore-walk": {
@@ -3621,7 +3635,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "3.0.4"
+						"minimatch": "^3.0.4"
 					}
 				},
 				"inflight": {
@@ -3630,8 +3644,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -3650,7 +3664,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"isarray": {
@@ -3664,7 +3678,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -3677,8 +3691,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
@@ -3687,7 +3701,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "2.2.4"
+						"minipass": "^2.2.1"
 					}
 				},
 				"mkdirp": {
@@ -3710,9 +3724,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "2.6.9",
-						"iconv-lite": "0.4.21",
-						"sax": "1.2.4"
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -3721,16 +3735,16 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "1.0.3",
-						"mkdirp": "0.5.1",
-						"needle": "2.2.0",
-						"nopt": "4.0.1",
-						"npm-packlist": "1.1.10",
-						"npmlog": "4.1.2",
-						"rc": "1.2.7",
-						"rimraf": "2.6.2",
-						"semver": "5.5.0",
-						"tar": "4.4.1"
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.0",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4"
 					}
 				},
 				"nopt": {
@@ -3739,8 +3753,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1.1.1",
-						"osenv": "0.1.5"
+						"abbrev": "1",
+						"osenv": "^0.1.4"
 					}
 				},
 				"npm-bundled": {
@@ -3755,8 +3769,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "3.0.1",
-						"npm-bundled": "1.0.3"
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
 					}
 				},
 				"npmlog": {
@@ -3765,10 +3779,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -3787,7 +3801,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
@@ -3808,8 +3822,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -3830,10 +3844,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "0.5.1",
-						"ini": "1.3.5",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "^0.5.1",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -3850,13 +3864,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"rimraf": {
@@ -3865,7 +3879,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
@@ -3908,9 +3922,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"string_decoder": {
@@ -3919,7 +3933,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "~5.1.0"
 					}
 				},
 				"strip-ansi": {
@@ -3927,7 +3941,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
@@ -3942,13 +3956,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "1.0.1",
-						"fs-minipass": "1.2.5",
-						"minipass": "2.2.4",
-						"minizlib": "1.1.0",
-						"mkdirp": "0.5.1",
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
+						"chownr": "^1.0.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.2.4",
+						"minizlib": "^1.1.0",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -3963,7 +3977,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "1.0.2"
+						"string-width": "^1.0.2"
 					}
 				},
 				"wrappy": {
@@ -3981,7 +3995,8 @@
 		"function-bind": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+			"dev": true
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
@@ -3995,12 +4010,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-base": {
@@ -4009,8 +4024,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"glob-parent": {
@@ -4019,7 +4034,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "2.0.1"
+				"is-glob": "^2.0.0"
 			}
 		},
 		"globals": {
@@ -4034,18 +4049,19 @@
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 			"dev": true,
 			"requires": {
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"glob": "7.1.2",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"glob": "^7.0.3",
+				"object-assign": "^4.0.1",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"graceful-readlink": {
 			"version": "1.0.1",
@@ -4057,8 +4073,9 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
-				"function-bind": "1.1.0"
+				"function-bind": "^1.0.2"
 			}
 		},
 		"has-ansi": {
@@ -4067,7 +4084,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-binary": {
@@ -4105,14 +4122,15 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.1"
 			}
 		},
 		"hosted-git-info": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-			"integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc="
+			"integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+			"dev": true
 		},
 		"http-errors": {
 			"version": "1.6.1",
@@ -4123,7 +4141,7 @@
 				"depd": "1.1.0",
 				"inherits": "2.0.3",
 				"setprototypeof": "1.0.3",
-				"statuses": "1.3.1"
+				"statuses": ">= 1.3.1 < 2"
 			}
 		},
 		"http-proxy": {
@@ -4132,8 +4150,8 @@
 			"integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
 			"dev": true,
 			"requires": {
-				"eventemitter3": "1.2.0",
-				"requires-port": "1.0.0"
+				"eventemitter3": "1.x.x",
+				"requires-port": "1.x.x"
 			}
 		},
 		"https-browserify": {
@@ -4178,8 +4196,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -4194,20 +4212,20 @@
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "3.1.0",
-				"chalk": "2.4.1",
-				"cli-cursor": "2.1.0",
-				"cli-width": "2.2.0",
-				"external-editor": "2.2.0",
-				"figures": "2.0.0",
-				"lodash": "4.17.4",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^2.0.4",
+				"figures": "^2.0.0",
+				"lodash": "^4.3.0",
 				"mute-stream": "0.0.7",
-				"run-async": "2.3.0",
-				"rx-lite": "4.0.8",
-				"rx-lite-aggregates": "4.0.8",
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"through": "2.3.8"
+				"run-async": "^2.2.0",
+				"rx-lite": "^4.0.8",
+				"rx-lite-aggregates": "^4.0.8",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^4.0.0",
+				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4222,7 +4240,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.3"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -4231,9 +4249,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -4248,7 +4266,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -4257,7 +4275,7 @@
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -4268,13 +4286,14 @@
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
 			"dev": true,
 			"requires": {
-				"loose-envify": "1.3.1"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -4282,7 +4301,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "1.8.0"
+				"binary-extensions": "^1.0.0"
 			}
 		},
 		"is-buffer": {
@@ -4295,8 +4314,9 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"dev": true,
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-callable": {
@@ -4323,7 +4343,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -4344,7 +4364,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -4359,7 +4379,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"is-number": {
@@ -4368,7 +4388,7 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-path-cwd": {
@@ -4383,7 +4403,7 @@
 			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "1.0.1"
+				"is-path-inside": "^1.0.0"
 			}
 		},
 		"is-path-inside": {
@@ -4392,7 +4412,7 @@
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "1.0.2"
+				"path-is-inside": "^1.0.1"
 			}
 		},
 		"is-posix-bracket": {
@@ -4419,7 +4439,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "1.0.1"
+				"has": "^1.0.1"
 			}
 		},
 		"is-resolvable": {
@@ -4443,7 +4463,8 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isbinaryfile": {
 			"version": "3.0.2",
@@ -4472,8 +4493,8 @@
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"dev": true,
 			"requires": {
-				"node-fetch": "1.7.1",
-				"whatwg-fetch": "2.0.3"
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"jasmine-core": {
@@ -4494,8 +4515,8 @@
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsesc": {
@@ -4534,7 +4555,7 @@
 			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
 			"dev": true,
 			"requires": {
-				"array-includes": "3.0.3"
+				"array-includes": "^3.0.3"
 			}
 		},
 		"karma": {
@@ -4543,33 +4564,33 @@
 			"integrity": "sha1-b3oaQGRG+i4YfslTmGmPTO5HYmk=",
 			"dev": true,
 			"requires": {
-				"bluebird": "3.5.0",
-				"body-parser": "1.17.2",
-				"chokidar": "1.7.0",
-				"colors": "1.1.2",
-				"combine-lists": "1.0.1",
-				"connect": "3.6.2",
-				"core-js": "2.4.1",
-				"di": "0.0.1",
-				"dom-serialize": "2.2.1",
-				"expand-braces": "0.1.2",
-				"glob": "7.1.2",
-				"graceful-fs": "4.1.11",
-				"http-proxy": "1.16.2",
-				"isbinaryfile": "3.0.2",
-				"lodash": "3.10.1",
-				"log4js": "0.6.38",
-				"mime": "1.3.6",
-				"minimatch": "3.0.4",
-				"optimist": "0.6.1",
-				"qjobs": "1.1.5",
-				"range-parser": "1.2.0",
-				"rimraf": "2.6.1",
-				"safe-buffer": "5.1.1",
+				"bluebird": "^3.3.0",
+				"body-parser": "^1.16.1",
+				"chokidar": "^1.4.1",
+				"colors": "^1.1.0",
+				"combine-lists": "^1.0.0",
+				"connect": "^3.6.0",
+				"core-js": "^2.2.0",
+				"di": "^0.0.1",
+				"dom-serialize": "^2.2.0",
+				"expand-braces": "^0.1.1",
+				"glob": "^7.1.1",
+				"graceful-fs": "^4.1.2",
+				"http-proxy": "^1.13.0",
+				"isbinaryfile": "^3.0.0",
+				"lodash": "^3.8.0",
+				"log4js": "^0.6.31",
+				"mime": "^1.3.4",
+				"minimatch": "^3.0.2",
+				"optimist": "^0.6.1",
+				"qjobs": "^1.1.4",
+				"range-parser": "^1.2.0",
+				"rimraf": "^2.6.0",
+				"safe-buffer": "^5.0.1",
 				"socket.io": "1.7.3",
-				"source-map": "0.5.6",
+				"source-map": "^0.5.3",
 				"tmp": "0.0.31",
-				"useragent": "2.1.13"
+				"useragent": "^2.1.12"
 			},
 			"dependencies": {
 				"core-js": {
@@ -4592,8 +4613,8 @@
 			"integrity": "sha1-vlrnxCZPmgouIuPZhL6zJa2SyMs=",
 			"dev": true,
 			"requires": {
-				"fs-access": "1.0.1",
-				"which": "1.2.14"
+				"fs-access": "^1.0.0",
+				"which": "^1.2.1"
 			}
 		},
 		"karma-firefox-launcher": {
@@ -4620,11 +4641,11 @@
 			"integrity": "sha1-OdX9Lt7qPMPvW0BZibN9Ww5qO04=",
 			"dev": true,
 			"requires": {
-				"async": "0.9.2",
-				"loader-utils": "0.2.17",
-				"lodash": "3.10.1",
-				"source-map": "0.1.43",
-				"webpack-dev-middleware": "1.11.0"
+				"async": "~0.9.0",
+				"loader-utils": "^0.2.5",
+				"lodash": "^3.8.0",
+				"source-map": "^0.1.41",
+				"webpack-dev-middleware": "^1.0.11"
 			},
 			"dependencies": {
 				"lodash": {
@@ -4639,7 +4660,7 @@
 					"integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
 					"dev": true,
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -4650,7 +4671,7 @@
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dev": true,
 			"requires": {
-				"is-buffer": "1.1.5"
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"lazy-cache": {
@@ -4665,19 +4686,20 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"load-json-file": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"strip-bom": "3.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"loader-utils": {
@@ -4686,32 +4708,35 @@
 			"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 			"dev": true,
 			"requires": {
-				"big.js": "3.1.3",
-				"emojis-list": "2.1.0",
-				"json5": "0.5.1",
-				"object-assign": "4.1.1"
+				"big.js": "^3.1.3",
+				"emojis-list": "^2.0.0",
+				"json5": "^0.5.0",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"locate-path": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			},
 			"dependencies": {
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
 				}
 			}
 		},
 		"lodash": {
 			"version": "4.17.4",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+			"dev": true
 		},
 		"lodash._baseassign": {
 			"version": "3.2.0",
@@ -4719,8 +4744,8 @@
 			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
 			"dev": true,
 			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash.keys": "3.1.2"
+				"lodash._basecopy": "^3.0.0",
+				"lodash.keys": "^3.0.0"
 			}
 		},
 		"lodash._basecopy": {
@@ -4741,9 +4766,9 @@
 			"integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
 			"dev": true,
 			"requires": {
-				"lodash._bindcallback": "3.0.1",
-				"lodash._isiterateecall": "3.0.9",
-				"lodash.restparam": "3.6.1"
+				"lodash._bindcallback": "^3.0.0",
+				"lodash._isiterateecall": "^3.0.0",
+				"lodash.restparam": "^3.0.0"
 			}
 		},
 		"lodash._getnative": {
@@ -4764,9 +4789,9 @@
 			"integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
 			"dev": true,
 			"requires": {
-				"lodash._baseassign": "3.2.0",
-				"lodash._createassigner": "3.1.1",
-				"lodash.keys": "3.1.2"
+				"lodash._baseassign": "^3.0.0",
+				"lodash._createassigner": "^3.0.0",
+				"lodash.keys": "^3.0.0"
 			}
 		},
 		"lodash.isarguments": {
@@ -4787,9 +4812,9 @@
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
 			"dev": true,
 			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
 			}
 		},
 		"lodash.restparam": {
@@ -4804,8 +4829,8 @@
 			"integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "1.0.34",
-				"semver": "4.3.6"
+				"readable-stream": "~1.0.2",
+				"semver": "~4.3.3"
 			},
 			"dependencies": {
 				"isarray": {
@@ -4820,10 +4845,10 @@
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
 				},
 				"semver": {
@@ -4852,7 +4877,7 @@
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"dev": true,
 			"requires": {
-				"js-tokens": "3.0.1"
+				"js-tokens": "^3.0.0"
 			}
 		},
 		"lru-cache": {
@@ -4861,8 +4886,8 @@
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"media-typer": {
@@ -4877,8 +4902,8 @@
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"dev": true,
 			"requires": {
-				"errno": "0.1.4",
-				"readable-stream": "2.3.2"
+				"errno": "^0.1.3",
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"micromatch": {
@@ -4887,19 +4912,19 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.3"
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
 			}
 		},
 		"mime": {
@@ -4920,7 +4945,7 @@
 			"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.27.0"
+				"mime-db": "~1.27.0"
 			}
 		},
 		"mimic-fn": {
@@ -4933,8 +4958,9 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -4955,7 +4981,8 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
@@ -4994,8 +5021,8 @@
 			"integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
 			"dev": true,
 			"requires": {
-				"encoding": "0.1.12",
-				"is-stream": "1.1.0"
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
 			}
 		},
 		"node-libs-browser": {
@@ -5004,28 +5031,28 @@
 			"integrity": "sha1-PicsCBnjCJNeJmdECNevDhSRuDs=",
 			"dev": true,
 			"requires": {
-				"assert": "1.4.1",
-				"browserify-zlib": "0.1.4",
-				"buffer": "4.9.1",
-				"console-browserify": "1.1.0",
-				"constants-browserify": "1.0.0",
+				"assert": "^1.1.1",
+				"browserify-zlib": "^0.1.4",
+				"buffer": "^4.9.0",
+				"console-browserify": "^1.1.0",
+				"constants-browserify": "^1.0.0",
 				"crypto-browserify": "3.3.0",
-				"domain-browser": "1.1.7",
-				"events": "1.1.1",
+				"domain-browser": "^1.1.1",
+				"events": "^1.0.0",
 				"https-browserify": "0.0.1",
-				"os-browserify": "0.2.1",
+				"os-browserify": "^0.2.0",
 				"path-browserify": "0.0.0",
-				"process": "0.11.10",
-				"punycode": "1.4.1",
-				"querystring-es3": "0.2.1",
-				"readable-stream": "2.3.2",
-				"stream-browserify": "2.0.1",
-				"stream-http": "2.7.2",
-				"string_decoder": "0.10.31",
-				"timers-browserify": "2.0.2",
+				"process": "^0.11.0",
+				"punycode": "^1.2.4",
+				"querystring-es3": "^0.2.0",
+				"readable-stream": "^2.0.5",
+				"stream-browserify": "^2.0.1",
+				"stream-http": "^2.3.1",
+				"string_decoder": "^0.10.25",
+				"timers-browserify": "^2.0.2",
 				"tty-browserify": "0.0.0",
-				"url": "0.11.0",
-				"util": "0.10.3",
+				"url": "^0.11.0",
+				"util": "^0.10.3",
 				"vm-browserify": "0.0.4"
 			},
 			"dependencies": {
@@ -5041,11 +5068,12 @@
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
 			"integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.4.2",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.3.0",
-				"validate-npm-package-license": "3.0.1"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -5054,7 +5082,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "1.0.2"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"null-check": {
@@ -5093,8 +5121,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
 			}
 		},
 		"on-finished": {
@@ -5112,7 +5140,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
@@ -5121,7 +5149,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"optimist": {
@@ -5130,8 +5158,8 @@
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8",
-				"wordwrap": "0.0.3"
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -5148,12 +5176,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			}
 		},
 		"options": {
@@ -5186,22 +5214,24 @@
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"mkdirp": "0.5.1",
-				"object-assign": "4.1.1"
+				"graceful-fs": "^4.1.4",
+				"mkdirp": "^0.5.1",
+				"object-assign": "^4.1.0"
 			}
 		},
 		"p-limit": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+			"dev": true
 		},
 		"p-locate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"dev": true,
 			"requires": {
-				"p-limit": "1.1.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"pako": {
@@ -5216,18 +5246,19 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"parse-json": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
 			"requires": {
-				"error-ex": "1.3.1"
+				"error-ex": "^1.2.0"
 			}
 		},
 		"parsejson": {
@@ -5236,7 +5267,7 @@
 			"integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
 			"dev": true,
 			"requires": {
-				"better-assert": "1.0.2"
+				"better-assert": "~1.0.0"
 			}
 		},
 		"parseqs": {
@@ -5245,7 +5276,7 @@
 			"integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
 			"dev": true,
 			"requires": {
-				"better-assert": "1.0.2"
+				"better-assert": "~1.0.0"
 			}
 		},
 		"parseuri": {
@@ -5254,7 +5285,7 @@
 			"integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
 			"dev": true,
 			"requires": {
-				"better-assert": "1.0.2"
+				"better-assert": "~1.0.0"
 			}
 		},
 		"parseurl": {
@@ -5273,8 +5304,9 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+			"dev": true,
 			"requires": {
-				"pinkie-promise": "2.0.1"
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"path-is-absolute": {
@@ -5298,14 +5330,16 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
 		},
 		"path-type": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"dev": true,
 			"requires": {
-				"pify": "2.3.0"
+				"pify": "^2.0.0"
 			}
 		},
 		"pbkdf2-compat": {
@@ -5317,27 +5351,31 @@
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"pkg-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
 			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+			"dev": true,
 			"requires": {
-				"find-up": "1.1.2"
+				"find-up": "^1.0.0"
 			}
 		},
 		"pluralize": {
@@ -5388,7 +5426,7 @@
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"dev": true,
 			"requires": {
-				"asap": "2.0.5"
+				"asap": "~2.0.3"
 			}
 		},
 		"prop-types": {
@@ -5397,8 +5435,8 @@
 			"integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
 			"dev": true,
 			"requires": {
-				"fbjs": "0.8.12",
-				"loose-envify": "1.3.1"
+				"fbjs": "^0.8.9",
+				"loose-envify": "^1.3.1"
 			}
 		},
 		"prr": {
@@ -5449,8 +5487,8 @@
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -5459,7 +5497,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -5468,7 +5506,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -5479,7 +5517,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.5"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -5515,10 +5553,10 @@
 			"integrity": "sha1-zn348ZQbA28Cssyp29DLHw6FXi0=",
 			"dev": true,
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.0"
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
 			},
 			"dependencies": {
 				"fbjs": {
@@ -5527,13 +5565,13 @@
 					"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
 					"dev": true,
 					"requires": {
-						"core-js": "1.2.7",
-						"isomorphic-fetch": "2.2.1",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1",
-						"promise": "7.3.1",
-						"setimmediate": "1.0.5",
-						"ua-parser-js": "0.7.13"
+						"core-js": "^1.0.0",
+						"isomorphic-fetch": "^2.1.1",
+						"loose-envify": "^1.0.0",
+						"object-assign": "^4.1.0",
+						"promise": "^7.1.1",
+						"setimmediate": "^1.0.5",
+						"ua-parser-js": "^0.7.9"
 					}
 				},
 				"prop-types": {
@@ -5542,9 +5580,9 @@
 					"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
 					"dev": true,
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				}
 			}
@@ -5555,10 +5593,10 @@
 			"integrity": "sha1-nMMHnD3NcNTG4BuEqrKn40wwP1g=",
 			"dev": true,
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.0"
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
 			},
 			"dependencies": {
 				"fbjs": {
@@ -5567,13 +5605,13 @@
 					"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
 					"dev": true,
 					"requires": {
-						"core-js": "1.2.7",
-						"isomorphic-fetch": "2.2.1",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1",
-						"promise": "7.3.1",
-						"setimmediate": "1.0.5",
-						"ua-parser-js": "0.7.13"
+						"core-js": "^1.0.0",
+						"isomorphic-fetch": "^2.1.1",
+						"loose-envify": "^1.0.0",
+						"object-assign": "^4.1.0",
+						"promise": "^7.1.1",
+						"setimmediate": "^1.0.5",
+						"ua-parser-js": "^0.7.9"
 					}
 				},
 				"prop-types": {
@@ -5582,9 +5620,9 @@
 					"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
 					"dev": true,
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
 					}
 				}
 			}
@@ -5593,27 +5631,30 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"dev": true,
 			"requires": {
-				"load-json-file": "2.0.0",
-				"normalize-package-data": "2.3.8",
-				"path-type": "2.0.0"
+				"load-json-file": "^2.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^2.0.0"
 			}
 		},
 		"read-pkg-up": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"dev": true,
 			"requires": {
-				"find-up": "2.1.0",
-				"read-pkg": "2.0.0"
+				"find-up": "^2.0.0",
+				"read-pkg": "^2.0.0"
 			},
 			"dependencies": {
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				}
 			}
@@ -5624,13 +5665,13 @@
 			"integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
 			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~1.0.6",
+				"safe-buffer": "~5.1.0",
+				"string_decoder": "~1.0.0",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readdirp": {
@@ -5639,10 +5680,10 @@
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"readable-stream": "2.3.2",
-				"set-immediate-shim": "1.0.1"
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"readable-stream": "^2.0.2",
+				"set-immediate-shim": "^1.0.1"
 			}
 		},
 		"regenerate": {
@@ -5663,9 +5704,9 @@
 			"integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.23.0",
-				"babel-types": "6.25.0",
-				"private": "0.1.7"
+				"babel-runtime": "^6.18.0",
+				"babel-types": "^6.19.0",
+				"private": "^0.1.6"
 			}
 		},
 		"regex-cache": {
@@ -5674,8 +5715,8 @@
 			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "0.1.3",
-				"is-primitive": "2.0.0"
+				"is-equal-shallow": "^0.1.3",
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"regexpp": {
@@ -5690,9 +5731,9 @@
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"dev": true,
 			"requires": {
-				"regenerate": "1.3.2",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
+				"regenerate": "^1.2.1",
+				"regjsgen": "^0.2.0",
+				"regjsparser": "^0.1.4"
 			}
 		},
 		"regjsgen": {
@@ -5707,7 +5748,7 @@
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
 			"requires": {
-				"jsesc": "0.5.0"
+				"jsesc": "~0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -5742,7 +5783,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"require-uncached": {
@@ -5751,8 +5792,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "0.1.0",
-				"resolve-from": "1.0.1"
+				"caller-path": "^0.1.0",
+				"resolve-from": "^1.0.0"
 			}
 		},
 		"requires-port": {
@@ -5765,8 +5806,9 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"dev": true,
 			"requires": {
-				"path-parse": "1.0.6"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"resolve-from": {
@@ -5781,8 +5823,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "2.0.1",
-				"signal-exit": "3.0.2"
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"right-align": {
@@ -5791,7 +5833,7 @@
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
 			"dev": true,
 			"requires": {
-				"align-text": "0.1.4"
+				"align-text": "^0.1.1"
 			}
 		},
 		"rimraf": {
@@ -5800,7 +5842,7 @@
 			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			}
 		},
 		"ripemd160": {
@@ -5815,7 +5857,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "2.1.0"
+				"is-promise": "^2.1.0"
 			}
 		},
 		"rx-lite": {
@@ -5830,7 +5872,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "4.0.8"
+				"rx-lite": "*"
 			}
 		},
 		"rxjs": {
@@ -5839,7 +5881,7 @@
 			"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
 			"dev": true,
 			"requires": {
-				"tslib": "1.9.3"
+				"tslib": "^1.9.0"
 			}
 		},
 		"safe-buffer": {
@@ -5857,7 +5899,8 @@
 		"semver": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-			"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+			"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
@@ -5889,7 +5932,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -5916,7 +5959,7 @@
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0"
+				"is-fullwidth-code-point": "^2.0.0"
 			}
 		},
 		"socket.io": {
@@ -6079,26 +6122,29 @@
 			"integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
 			"dev": true,
 			"requires": {
-				"source-map": "0.5.6"
+				"source-map": "^0.5.6"
 			}
 		},
 		"spdx-correct": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"dev": true,
 			"requires": {
-				"spdx-license-ids": "1.2.2"
+				"spdx-license-ids": "^1.0.2"
 			}
 		},
 		"spdx-expression-parse": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+			"dev": true
 		},
 		"spdx-license-ids": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+			"dev": true
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
@@ -6118,8 +6164,8 @@
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.2"
+				"inherits": "~2.0.1",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"stream-http": {
@@ -6128,11 +6174,11 @@
 			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
 			"dev": true,
 			"requires": {
-				"builtin-status-codes": "3.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.2",
-				"to-arraybuffer": "1.0.1",
-				"xtend": "4.0.1"
+				"builtin-status-codes": "^3.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.2.6",
+				"to-arraybuffer": "^1.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"string-width": {
@@ -6141,8 +6187,8 @@
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6157,7 +6203,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -6168,7 +6214,7 @@
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -6177,13 +6223,14 @@
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
@@ -6203,12 +6250,12 @@
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"ajv-keywords": "2.1.1",
-				"chalk": "2.4.1",
-				"lodash": "4.17.4",
+				"ajv": "^5.2.3",
+				"ajv-keywords": "^2.1.0",
+				"chalk": "^2.1.0",
+				"lodash": "^4.17.4",
 				"slice-ansi": "1.0.0",
-				"string-width": "2.1.1"
+				"string-width": "^2.1.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6217,7 +6264,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.3"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -6226,9 +6273,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -6243,7 +6290,7 @@
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -6272,7 +6319,7 @@
 			"integrity": "sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=",
 			"dev": true,
 			"requires": {
-				"setimmediate": "1.0.5"
+				"setimmediate": "^1.0.4"
 			}
 		},
 		"tmp": {
@@ -6281,7 +6328,7 @@
 			"integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "1.0.2"
+				"os-tmpdir": "~1.0.1"
 			}
 		},
 		"to-array": {
@@ -6326,7 +6373,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"type-is": {
@@ -6336,7 +6383,7 @@
 			"dev": true,
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "2.1.15"
+				"mime-types": "~2.1.15"
 			}
 		},
 		"typedarray": {
@@ -6357,10 +6404,10 @@
 			"integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
 			"dev": true,
 			"requires": {
-				"async": "0.2.10",
-				"source-map": "0.5.6",
-				"uglify-to-browserify": "1.0.2",
-				"yargs": "3.10.0"
+				"async": "~0.2.6",
+				"source-map": "~0.5.1",
+				"uglify-to-browserify": "~1.0.0",
+				"yargs": "~3.10.0"
 			},
 			"dependencies": {
 				"async": {
@@ -6395,7 +6442,7 @@
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 			"dev": true,
 			"requires": {
-				"punycode": "2.1.1"
+				"punycode": "^2.1.0"
 			},
 			"dependencies": {
 				"punycode": {
@@ -6436,8 +6483,8 @@
 			"integrity": "sha1-u6Q+iqJNXOuDwpN0c+EC4h33TBA=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "2.2.4",
-				"tmp": "0.0.31"
+				"lru-cache": "2.2.x",
+				"tmp": "0.0.x"
 			},
 			"dependencies": {
 				"lru-cache": {
@@ -6483,16 +6530,17 @@
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
 			"dev": true,
 			"requires": {
-				"user-home": "1.1.1"
+				"user-home": "^1.1.1"
 			}
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"dev": true,
 			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
+				"spdx-correct": "~1.0.0",
+				"spdx-expression-parse": "~1.0.0"
 			}
 		},
 		"vm-browserify": {
@@ -6516,9 +6564,9 @@
 			"integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
 			"dev": true,
 			"requires": {
-				"async": "0.9.2",
-				"chokidar": "1.7.0",
-				"graceful-fs": "4.1.11"
+				"async": "^0.9.0",
+				"chokidar": "^1.0.0",
+				"graceful-fs": "^4.1.2"
 			}
 		},
 		"webpack": {
@@ -6527,21 +6575,21 @@
 			"integrity": "sha1-T/MfU9sDM55VFkqdRo7gMklo/pg=",
 			"dev": true,
 			"requires": {
-				"acorn": "3.3.0",
-				"async": "1.5.2",
-				"clone": "1.0.2",
-				"enhanced-resolve": "0.9.1",
-				"interpret": "0.6.6",
-				"loader-utils": "0.2.17",
-				"memory-fs": "0.3.0",
-				"mkdirp": "0.5.1",
-				"node-libs-browser": "0.7.0",
-				"optimist": "0.6.1",
-				"supports-color": "3.2.3",
-				"tapable": "0.1.10",
-				"uglify-js": "2.7.5",
-				"watchpack": "0.2.9",
-				"webpack-core": "0.6.9"
+				"acorn": "^3.0.0",
+				"async": "^1.3.0",
+				"clone": "^1.0.2",
+				"enhanced-resolve": "~0.9.0",
+				"interpret": "^0.6.4",
+				"loader-utils": "^0.2.11",
+				"memory-fs": "~0.3.0",
+				"mkdirp": "~0.5.0",
+				"node-libs-browser": "^0.7.0",
+				"optimist": "~0.6.0",
+				"supports-color": "^3.1.0",
+				"tapable": "~0.1.8",
+				"uglify-js": "~2.7.3",
+				"watchpack": "^0.2.1",
+				"webpack-core": "~0.6.9"
 			},
 			"dependencies": {
 				"acorn": {
@@ -6568,8 +6616,8 @@
 					"integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
 					"dev": true,
 					"requires": {
-						"errno": "0.1.4",
-						"readable-stream": "2.3.2"
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
 					}
 				},
 				"supports-color": {
@@ -6578,7 +6626,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6589,8 +6637,8 @@
 			"integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
 			"dev": true,
 			"requires": {
-				"source-list-map": "0.1.8",
-				"source-map": "0.4.4"
+				"source-list-map": "~0.1.7",
+				"source-map": "~0.4.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -6599,7 +6647,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -6610,10 +6658,10 @@
 			"integrity": "sha1-CWkdCXOjCtH4Ksc6EuIIfwpHVPk=",
 			"dev": true,
 			"requires": {
-				"memory-fs": "0.4.1",
-				"mime": "1.3.6",
-				"path-is-absolute": "1.0.1",
-				"range-parser": "1.2.0"
+				"memory-fs": "~0.4.1",
+				"mime": "^1.3.4",
+				"path-is-absolute": "^1.0.0",
+				"range-parser": "^1.0.3"
 			}
 		},
 		"whatwg-fetch": {
@@ -6628,7 +6676,7 @@
 			"integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"window-size": {
@@ -6655,7 +6703,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "0.5.1"
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"ws": {
@@ -6664,8 +6712,8 @@
 			"integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
 			"dev": true,
 			"requires": {
-				"options": "0.0.6",
-				"ultron": "1.0.2"
+				"options": ">=0.0.5",
+				"ultron": "1.0.x"
 			}
 		},
 		"wtf-8": {
@@ -6698,9 +6746,9 @@
 			"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
 			"dev": true,
 			"requires": {
-				"camelcase": "1.2.1",
-				"cliui": "2.1.0",
-				"decamelize": "1.2.0",
+				"camelcase": "^1.0.2",
+				"cliui": "^2.1.0",
+				"decamelize": "^1.0.0",
 				"window-size": "0.1.0"
 			}
 		},


### PR DESCRIPTION
`unmountHabitats` call signature was missing from `index.d.ts` and could not be called if you are using TypeScript. It's now been added.